### PR TITLE
Updated getHerokuAssignedPort()

### DIFF
--- a/_posts/tutorials/2017-05-25-javalin-heroku-example.md
+++ b/_posts/tutorials/2017-05-25-javalin-heroku-example.md
@@ -119,19 +119,19 @@ import io.javalin.Javalin;
 
 public class Main {
 
-    public static void main(String[] args) {
-        Javalin app = Javalin.create()
-            .start(getHerokuAssignedPort())
-            .get("/", ctx -> ctx.result("Hello Heroku"));
-    }
+  public static void main(String[] args) {
+    Javalin app = Javalin.create()
+        .start(getHerokuAssignedPort())
+        .get("/", ctx -> ctx.result("Hello Heroku"));
+  }
 
-    private static int getHerokuAssignedPort() {
-        ProcessBuilder processBuilder = new ProcessBuilder();
-        if (processBuilder.environment().get("PORT") != null) {
-            return Integer.parseInt(processBuilder.environment().get("PORT"));
-        }
-        return 7000;
+  private static int getHerokuAssignedPort() {
+    String herokuPort = System.getenv("PORT");
+    if (herokuPort != null) {
+      return Integer.parseInt(herokuPort);
     }
+    return 7000;
+  }
 
 }
 ~~~


### PR DESCRIPTION
There's a simpler way to implement `getHerokuAssignedPort()`, using `System.getenv(String name)` instead of `ProcessBuilder`.

I updated `getHerokuAssignedPort()` to use this simpler approach instead.