### PR TITLE
Update sdk naming scheme and version

### DIFF
--- a/_posts/tutorials/2018-09-27-javalin-graalvm-example.md
+++ b/_posts/tutorials/2018-09-27-javalin-graalvm-example.md
@@ -45,7 +45,7 @@ While I recommend performing builds in Docker, it’s very helpful to install Gr
 
 Install GraalVM JDK:
 
-`sdk install java 1.0.0-rc6-graal && sdk use java 1.0.0-rc6-graal`
+`sdk install java 1.0.0-rc-16-grl && sdk use java 1.0.0-rc-16-grl`
 
 Let’s start with a very simple Hello World:
 


### PR DESCRIPTION
sdkman changed the naming scheme so the old shell command will fail with the following message:

```
 ▲ ~ sdk install java 1.0.0-rc6-graal && sdk use java 1.0.0-rc6-graal

Stop! java 1.0.0-rc6-graal is not available. Possible causes:
 * 1.0.0-rc6-graal is an invalid version
 * java binaries are incompatible with Darwin
 * java has not been released yet
```