### PR TITLE
Update 2019-07-31-simple-frontends-with-javalin-and-vue.md

### DIFF
--- a/_posts/tutorials/2019-07-31-simple-frontends-with-javalin-and-vue.md
+++ b/_posts/tutorials/2019-07-31-simple-frontends-with-javalin-and-vue.md
@@ -93,7 +93,7 @@ Let's create `/src/main/resources/vue/layout.html`:
 <html>
     <head>
         <meta charset="utf8">
-        <script src="/webjars/vue/2.6.10/dist/vue.min.js"></script>
+        <script src="/webjars/vue/2.6.10/vue.min.js"></script>
         @componentRegistration
     </head>
     <body>


### PR DESCRIPTION
I tried the example, and found the location of vue.js  should be /webjars/vue/2.6.10/vue.min.js, instead of /webjars/vue/2.6.10/dist/vue.min.js.