### PR TITLE
Remove Java typo from Kotlin code example

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -617,7 +617,7 @@ val instant = ctx.pathParam<Instant>("timestamp-ms").get()
 
 // Form Parameters
 val color = ctx.formParam("color");
-val exampleId = ctx.formParam<Int>("exampleId", Integer.class).get();
+val exampleId = ctx.formParam<Int>("exampleId").get();
 val size = ctx.formParam<Int>("size").check(i -> i > 4).get();
 val qty = ctx.formParam<Int>("qty", 12).get(); // may default to value 12
 val instant = ctx.queryParam<Instant>("ts").get();


### PR DESCRIPTION
Removed some Java code that was accidentally left in the Kotlin example from last PR addressing  https://github.com/tipsy/javalin/issues/900