### PR TITLE
SameSite=strict security hardening in Jetty session tutorial

### DIFF
--- a/_posts/tutorials/2018-09-02-jetty-session-handling-java.md
+++ b/_posts/tutorials/2018-09-02-jetty-session-handling-java.md
@@ -220,6 +220,33 @@ val app = Javalin.create {
 As we saw earlier, the `SessionHandler` has a `SessionCache` which again has a `SessionDataStore`,
 so no further configuration is required.  All session configuration happens through Jetty classes.
 
+#### SameSite session cookie settings
+By default Jetty uses lenient cookie security settings. In order to harden and to mitigate 
+cross-site request forgery ([CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery)) attacks, it is useful 
+to set the `SameSite=strict` cookie flag. This is particularly recommended if the `JSESSIONID` cookie is also used 
+directly or indirectly for authentication purposes.
+{% capture java %}
+private static Supplier<SessionHandler> customSessionHandlerSupplier() {
+    final SessionHandler sessionHandler = new SessionHandler();
+    // [..] add persistence DB etc. management here [..]
+    sessionHandler.getSessionCookieConfig().setHttpOnly(true);
+    sessionHandler.getSessionCookieConfig().setSecure(true);
+    sessionHandler.getSessionCookieConfig().setComment("__SAME_SITE_STRICT__");
+    return () -> sessionHandler;
+}
+{% endcapture %}
+{% capture kotlin %}
+private fun customSessionHandlerSupplier(): SessionHandler = SessionHandler().apply {
+    // [..] add persistence DB etc. management here [..]
+    sessionCookieConfig.isHttpOnly = true
+    sessionCookieConfig.isSecure = true
+    sessionCookieConfig.comment = "__SAME_SITE_STRICT__"
+}
+{% endcapture %}
+N.B. some browsers (see e.g. [here](https://blog.chromium.org/2020/02/samesite-cookie-changes-in-february.html)) 
+will eventually further restrict cookies to first-party access by default in case the `SameSite` and `secure` 
+cookie settings are not being set.
+
 ### Working with sessions
 Sessions are a great way to keep a trusted state for your connected clients.
 If you use a session database, values stored in the session store can be retrieved by each of your running instances.


### PR DESCRIPTION
This adds a small section on how to add `SameSite=strict` cookie settings to the underlying Jetty JSESSIONID cookie that is being used by Javalin. The underlying Jetty server allows this to be set, but does this not (yet) by default and thus needs to be set explicitly if hardened security concepts are required (e.g. for authentication, internal user state tracking, etc.).

N.B. While the stricter SameSite cookie handling roll-out has been (again) temporarily delayed by Google for Chrome (this time due to COVID-19), this will certainly come back and in turn likely also adopted by other browsers and -- more importantly -- this is a prudent measure to mitigate cross-site request forgery attacks.

Thanks to @tipsy for pointing me to the handler to add this and for encouraging this PR.