### PR TITLE
Fix invalid doc about throwing

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -791,7 +791,7 @@ Javalin comes with a built in class called `HttpResponseException`, which can be
 If the client accepts JSON, a JSON object is returned. Otherwise a plain text response is returned.
 
 ```java
-app.post("/") { throw ForbiddenResponse("Off limits!") }
+app.post("/") { throw new ForbiddenResponse("Off limits!") }
 ```
 If client accepts JSON:
 ```java


### PR DESCRIPTION
The example shown for `Default Responses` shows a invalid way.
In order to define a String to use as response, do you need to use `throw new` and not just `throw`

On a separate note does it mention that you can provide a `HashMap<String, String>` for the details list, but there isn't a Constructor or method for this in (at least) the ForbiddenResponse?