### PR TITLE
fix typo in queryParams usage

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -228,7 +228,7 @@ port()                                  // request port
 protocol()                              // request protocol
 queryParam("name")                      // query param by name as string
 queryParamAsClass("name", clazz)        // query param parameter by name, as validator typed as specified class
-queryParams("name)                      // list of query parameters by name
+queryParams("name")                      // list of query parameters by name
 queryParamMap()                         // map of all query parameters
 queryString()                           // full query string
 scheme()                                // request scheme


### PR DESCRIPTION
Missing a closing quote for the string.