### PR TITLE
docs: Replace example that uses `ctx.splat`

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -148,12 +148,12 @@ Handler paths can also include wildcard parameters:
 
 {% capture java %}
 app.get("/path/*", ctx -> { // will match anything starting with /path/
-    ctx.result("Hello: " + ctx.splat(0) + " and " + ctx.splat(1));
+    ctx.result("You are here because " + ctx.path() + " matches " + ctx.matchedPath());
 });
 {% endcapture %}
 {% capture kotlin %}
 app.get("/path/*") { ctx -> // will match anything starting with /path/
-    ctx.result("Hello: " + ctx.splat(0) + " and " + ctx.splat(1))
+    ctx.result("You are here because " + ctx.path() + " matches " + ctx.matchedPath())
 }
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}


### PR DESCRIPTION
Hi there! First PR for this project, so all feedback is most welcome!

I was following the examples in the website. It turns out to be that this particular example is using a method called `splat` which is no more in v4.