### PR TITLE
fix typo in Configuration Static Files

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -1030,7 +1030,7 @@ showJavalinBanner = true;                       // show the glorious Javalin ban
 ```
 
 ### Static Files
-You can enabled static file serving by doing `config.addStaticFiles("/diretory", location)`.
+You can enabled static file serving by doing `config.addStaticFiles("/directory", location)`.
 Static resource handling is done **after** endpoint matching, meaning your own
 GET endpoints have higher priority. The process looks like this:
 


### PR DESCRIPTION
missing 'c' in "directory"