### PR TITLE
Make path-parameters more accessible

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -186,7 +186,7 @@ app.get("/path/*") { ctx -> // will match anything starting with /path/
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
 However, you cannot extract the value of a wildcard.
-Use a slash accepting path-parameter (`<param-name>`) if you need this behavior.
+Use a slash accepting path-parameter (`<param-name>` instead of `{param-name}`) if you need this behavior.
 
 ### After handlers
 After-handlers run after every request (even if an exception occurred)


### PR DESCRIPTION
The current docs do explain the expected behavior. However for beginners, this may not be immidiately obvious. Case in point i had to look at https://github.com/javalin/javalin/blob/master/javalin/src/test/java/io/javalin/TestRouting.kt to find any other mention of "slash accepting path-parameter".

I'd even be inclined to link the Above test Case too, as that contains a couple of examples. Alternatively it might be helpful to specify the exact behavior of the PathParser.

In any case, i hope this small contribution helps. I'm explicitely not creating an issue for this, as i think the change is small enough to be discussed in just a PR.

Anyway javalin is a cool project. Currently prototyping using it, as it is not as "bloaty" as Spring (Boot) or Micronaut in terms of dependencies specified within my pom.xml. Thanks!