### PR TITLE
Fix Kotlin docs for validation collect errors

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -719,7 +719,7 @@ val ageValidator = ctx.queryParamAsClass<Int>("age")
 val errors = ageValidator.errors()
 
 // Merges all errors from all validators in the list. Empty map if no errors exist.
-val manyErrors = listOf(ageValidator, otherValidator, ...)
+val manyErrors = listOf(ageValidator, otherValidator, ...).collectErrors()
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 


### PR DESCRIPTION
The docs say that the errors are turned into a map, which the Java code does with `JavalinValidation.collectErrors()`, but the Kotlin code only calls `listOf()`, I think it's missing a call to `.collectErrors()` extension function?