### PR TITLE
Limit deploy job to original repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository == 'javalin/javalin.github.io'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -61,6 +62,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.repository == 'javalin/javalin.github.io'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The deploy job fails on forks with a permission error. This is correct behaviour so we should allow the deploy job only for the main repository.