### PR TITLE
Make openapi URL a link

### DIFF
--- a/pages/plugins/openapi.md
+++ b/pages/plugins/openapi.md
@@ -6,4 +6,4 @@ permalink: /plugins/openapi
 ---
 
 This plugin has been moved out of the main repo,
-it now lives at https://github.com/javalin/javalin-openapi
+it now lives at [https://github.com/javalin/javalin-openapi](https://github.com/javalin/javalin-openapi)


### PR DESCRIPTION
This makes the plugins/openapi page link to the openapi plugin repository, instead of just containing a URL.

This page still ranks high on google, and I found copy-pasting the URL annoying :)