### PR TITLE
update javalin version to 5.6.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 javalinThreeVersion: 3.13.13
-javalinversion: 5.6.1
+javalinversion: 5.6.3
 slf4jversion: 2.0.7
 repourl: https://github.com/javalin/javalin.github.io
 description: Javalin - A lightweight Java and Kotlin web framework. Create REST APIs in Java or Kotlin easily.


### PR DESCRIPTION
Update version to 5.6.3 to be in sync with the main repo: https://github.com/javalin/javalin