### PR TITLE
Static configuration methods have been removed

### DIFF
--- a/pages/docs/migration-guide-5-6.md
+++ b/pages/docs/migration-guide-5-6.md
@@ -383,6 +383,7 @@ JavalinValidation.register(Custom.class, Custom::parse);
 JavalinRenderer.register(myFileRenderer)
 JavalinValidation.register(Custom.class, Custom::parse)
 {% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
 We've moved all these to the config for Javalin 6:
 {% capture java %}

--- a/pages/docs/migration-guide-5-6.md
+++ b/pages/docs/migration-guide-5-6.md
@@ -397,6 +397,7 @@ val app = Javalin.create { config ->
   config.validation.register(Custom.class, Custom::parse)
 }
 {% endcapture %}
+{% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
 ## Changes to private config
 In Javalin 5, you could access Javalin's private config through `app.cfg`, 

--- a/pages/docs/migration-guide-5-6.md
+++ b/pages/docs/migration-guide-5-6.md
@@ -372,6 +372,32 @@ ctx.async({ config ->
 {% endcapture %}
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
+## Static configuration methods have been removed
+In Javalin 5, there were some classes which had static methods for configuration:
+
+{% capture java %}
+JavalinRenderer.register(myFileRenderer);
+JavalinValidation.register(Custom.class, Custom::parse);
+{% endcapture %}
+{% capture kotlin %}
+JavalinRenderer.register(myFileRenderer)
+JavalinValidation.register(Custom.class, Custom::parse)
+{% endcapture %}
+
+We've moved all these to the same configuration method in Javalin 6:
+{% capture java %}
+var app = Javalin.create(config -> {
+  config.fileRenderer(myFileRenderer);
+  config.validation.register(MyCustom.class, MyCustom::parse);
+});
+{% endcapture %}
+{% capture kotlin %}
+val app = Javalin.create { config ->
+  config.fileRenderer(myFileRenderer)
+  config.validation.register(MyCustom.class, MyCustom::parse)
+}
+{% endcapture %}
+
 ## Changes to private config
 In Javalin 5, you could access Javalin's private config through `app.cfg`, 
 this has been change to `app.unsafeConfig()` in Javalin 6, in order to make it clear that it's not

--- a/pages/docs/migration-guide-5-6.md
+++ b/pages/docs/migration-guide-5-6.md
@@ -373,7 +373,7 @@ ctx.async({ config ->
 {% include macros/docsSnippet.html java=java kotlin=kotlin %}
 
 ## Static configuration methods have been removed
-In Javalin 5, there were some classes which had static methods for configuration:
+In Javalin 5, there were some classes which had their own static methods for configuration:
 
 {% capture java %}
 JavalinRenderer.register(myFileRenderer);
@@ -384,7 +384,7 @@ JavalinRenderer.register(myFileRenderer)
 JavalinValidation.register(Custom.class, Custom::parse)
 {% endcapture %}
 
-We've moved all these to the same configuration method in Javalin 6:
+We've moved all these to the config for Javalin 6:
 {% capture java %}
 var app = Javalin.create(config -> {
   config.fileRenderer(myFileRenderer);

--- a/pages/docs/migration-guide-5-6.md
+++ b/pages/docs/migration-guide-5-6.md
@@ -388,13 +388,13 @@ We've moved all these to the config for Javalin 6:
 {% capture java %}
 var app = Javalin.create(config -> {
   config.fileRenderer(myFileRenderer);
-  config.validation.register(MyCustom.class, MyCustom::parse);
+  config.validation.register(Custom.class, Custom::parse);
 });
 {% endcapture %}
 {% capture kotlin %}
 val app = Javalin.create { config ->
   config.fileRenderer(myFileRenderer)
-  config.validation.register(MyCustom.class, MyCustom::parse)
+  config.validation.register(Custom.class, Custom::parse)
 }
 {% endcapture %}
 


### PR DESCRIPTION
While trying out Javalin 6 I found out that there were some configuration methods which have been moved to the config.