### PR TITLE
Added deployment to AWS Lambda via AWS Lambda Web Adapter example

### DIFF
--- a/pages/docs/docs.md
+++ b/pages/docs/docs.md
@@ -1605,7 +1605,10 @@ Please contribute to the Javadoc if you can.
 To deploy Javalin, simply create a [jar with dependencies](https://maven.apache.org/plugins/maven-assembly-plugin/usage.html),
 then launch the jar with `java -jar filename.jar`. That's it.
 Javalin has an embedded server, so you don't need an application server.
-There is also a tutorial on [deploying Javalin to Heroku](/tutorials/heroku).
+
+Deploying Javalin to:
+* [Heroku](/tutorials/heroku) (tutorial)
+* [AWS / Lambda](https://github.com/awslabs/aws-lambda-web-adapter/tree/main/examples/javalin-zip) (example)
 
 ---
 


### PR DESCRIPTION
Added a link to an example application showing how to use the AWS Lambda Web Adapter to simplify deployment to AWS Lambda