### PR TITLE
Fix : Local setup for docker. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.4-alpine
+FROM ruby:3.2-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Fix for the issue https://github.com/javalin/website/issues/296 

Currently the [non docker based local setup guide](https://github.com/javalin/website/blob/d3609c53da87f966a7438db93c3baf473195d949/.github/CONTRIBUTING.md#L4) mentioned uses the latest ruby always. 

Can modify the Dockerfile also to use the latest ruby. But for now sticking with the standard and using the fixed version docker ruby:3.2-alpine